### PR TITLE
Add position option for the param macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Allowed options:
 |`type`         | atom     | mandatory. Example: `type: Integer`. See [Builtin types](#builtin-types) |
 |`required`     | boolean  | optional. Defaults to `false`. When `true`, a validation error is returned whenever the param is missing or its value is `nil`. |
 |`nested`       | boolean  | optional. Defaults to `false`. Denotes the param's type is a [nested request](#nested-types). |
+|`source`       | atom     | optional. Possible values `:path`, `:query`, `:body`.
 |`validator`    | function | optional. A [custom validator](#custom-validators) in the format `&Mod.fun/arity`. |
 |`regex`        | regex    | optional. A [builtin validator](#regex) |
 |`length`       | map      | optional. A [builtin validator](#length) |
@@ -126,6 +127,7 @@ Example:
 ```elixir
 param :email,
       type: String,
+      source: :body,
       regex: ~r/[a-z_.]+@[a-z_.]+/
 ```
 

--- a/lib/phoenix_params.ex
+++ b/lib/phoenix_params.ex
@@ -193,6 +193,7 @@ defmodule PhoenixParams do
       {required, opts} = Keyword.pop(opts, :required)
       {default, opts} = Keyword.pop(opts, :default)
       {nested, opts} = Keyword.pop(opts, :nested)
+      {source, opts} = Keyword.pop(opts, :source)
       builtin_validators = opts
 
       coercer =
@@ -223,6 +224,7 @@ defmodule PhoenixParams do
 
       param_opts = %{
         type: type,
+        source: source,
         coercer: coercer,
         validator: validator || List.first(builtin_validators),
         required: required,


### PR DESCRIPTION
The position option is added for the params macro. The idea of the
option is to define what kind of parameter it is expected:

 * path
 * query
 * body

Currently no validations for the values of the position option are executed.