### PR TITLE
Allow strings as names of the request parameters

### DIFF
--- a/lib/phoenix_params.ex
+++ b/lib/phoenix_params.ex
@@ -184,7 +184,7 @@ defmodule PhoenixParams do
   TODO: add support for arrays of nested type params.
   """
 
-  defmacro param(name, opts) when is_atom(name) or (is_list(name) and length(name) == 1) do
+  defmacro param(name, opts) when is_binary(name) or is_atom(name) or (is_list(name) and length(name) == 1) do
     quote location: :keep, bind_quoted: [name: name, opts: opts] do
       {type, opts} = Keyword.pop(opts, :type)
       typedef = Enum.find(@typedefs, &(elem(&1, 0) == type))
@@ -210,7 +210,7 @@ defmodule PhoenixParams do
             elem(typedef, 1)
         end
 
-      if Enum.any?(@paramdefs, &(elem(&1, 0) == name)) do
+      if Enum.any?(@paramdefs, &(to_string(elem(&1, 0)) == to_string(name))) do
         raise "Duplicate parameter: #{name}"
       end
 
@@ -238,10 +238,6 @@ defmodule PhoenixParams do
 
   defmacro __before_compile__(_env) do
     quote location: :keep do
-      defstruct Enum.map(@paramdefs, fn {name, opts} ->
-                  {name, opts[:default]}
-                end)
-
       def global_validators do
         @global_validators |> Enum.reverse()
       end


### PR DESCRIPTION
Background:
Phoenix handles request parameters as map with string keys.
Phoenix_params take these parameters from the conn, validates them
according to the definition provided by the user and puts them back
into the conn.
In the request definition only atoms were allowed as names of the
request parameters. So, when put back into the conn, the user should
have started working with atoms instead of strings.

In some cases it is more convinient for the user to continue using
strings instead of atoms. So, phoenix_params allow request parameters to
be define as string and when put back into the conn, the user will
continue working with strings instead of atoms.

The string representation of the parameters should remain unique among
all paramters. It means - it does not matter whether the parameter name
is string or atom, their string representations should not be equal.

Eg. It is now allowed to have `:token` and `"token"` as different
parameters because their string representations are the same.