### PR TITLE
Improve moduledoc

### DIFF
--- a/lib/phoenix_params.ex
+++ b/lib/phoenix_params.ex
@@ -9,7 +9,9 @@ defmodule PhoenixParams do
         plug Api.Plugs.Requests.User.Index when action in [:index]
 
         def index(conn, params) do
-          # params is now a map with atom keys and transformed values
+          # params is now a map with transformed values
+          # when params names are declared as atoms in the request definition
+          # params will be a map with atom keys
           user = params.user
           # ...
         end
@@ -26,6 +28,7 @@ defmodule PhoenixParams do
         param :date,
               type: Date,
               required: true,
+              source: :body,
               validator: &__MODULE__.validate_date/1
 
         param :merchant_id,
@@ -34,7 +37,7 @@ defmodule PhoenixParams do
 
         param :email,
               type: [String],
-              validaator: &__MODULE__.validate_email/1
+              validator: &__MODULE__.validate_email/1
 
         global_validator &__MODULE__.ensure_mid_or_email/1
 
@@ -72,7 +75,19 @@ defmodule PhoenixParams do
         end
       end
 
-  Supported types are:
+  Synopsis:
+    param <name>, <options>
+  where:
+    * name - either an atom or binary
+    * options - a keyword list:
+      ** type - mandatory. See below for possible values.
+      ** required - optional. Either true or false (default).
+      ** nested - optional. Either true or false (default). More info on nested types below
+      ** validator - optional. A custom validator function in the form &Module.function/arity
+      ** source - optional. Currently has no effect and serves a purely declarational purpose.
+        Can be useful for exposing detailed endpoint information (eg. openapi)
+
+  Supported types of the param are:
     * `String`
     * `Integer`
     * `Float`
@@ -131,7 +146,7 @@ defmodule PhoenixParams do
   - regex - validates the string against a regex pattern
 
   The package is designed to be a "plug" and:
-  - it changes the input map's string keys to atoms
+  - it will change the input map's keys to atoms for all params whose names are declared as such
   - it discards undefined params
   - it changes (coerces) the values to whatever type they correspond to
     This means that a definition like `param :age, type: Integer` will
@@ -184,7 +199,8 @@ defmodule PhoenixParams do
   TODO: add support for arrays of nested type params.
   """
 
-  defmacro param(name, opts) when is_binary(name) or is_atom(name) or (is_list(name) and length(name) == 1) do
+  defmacro param(name, opts)
+           when is_binary(name) or is_atom(name) or (is_list(name) and length(name) == 1) do
     quote location: :keep, bind_quoted: [name: name, opts: opts] do
       {type, opts} = Keyword.pop(opts, :type)
       typedef = Enum.find(@typedefs, &(elem(&1, 0) == type))
@@ -411,10 +427,15 @@ defmodule PhoenixParams do
           Enum.filter(validated_params, fn param ->
             case param do
               # global validation failed
-              {nil, _} -> true
+              {nil, _} ->
+                true
+
               # param validation or coercion failed
-              {_, {:error, _}} -> true
-              _ -> false
+              {_, {:error, _}} ->
+                true
+
+              _ ->
+                false
             end
           end)
 
@@ -454,7 +475,9 @@ defmodule PhoenixParams do
               conn
               |> put_status(400)
               |> halt
-              |> Phoenix.Controller.render(unquote(error_view), "400.json",
+              |> Phoenix.Controller.render(
+                unquote(error_view),
+                "400.json",
                 validation_failed: errors
               )
 


### PR DESCRIPTION
The moduledoc of the PhoenixParam module has been improved.
 * Structure of the param is described. (How to define a param in the
 request definition)
 * The moduledoc has been updated after the change that the names of the
 params can be strings. (previously it was only possible for the names
 of the params to be atoms)
 * Example of param with source field.
 * Typo is fixed.